### PR TITLE
Fix lower bound of _findKey method in crypto.py

### DIFF
--- a/mirage/libs/ble_utils/crypto.py
+++ b/mirage/libs/ble_utils/crypto.py
@@ -18,7 +18,7 @@ class BLECrypto:
 
 	@classmethod
 	def _findKey(cls,L,pMin,pMax,r,pres,preq,iat,ia,rat,ra,confirm):
-		i = 0
+		i = pMin
 		p1 = pres + preq + rat + iat
 		p2 = b"\x00\x00\x00\x00" + ia + ra
 		a = cls.xor128(p1,r)

--- a/mirage/modules/ble_mitm.py
+++ b/mirage/modules/ble_mitm.py
@@ -124,9 +124,9 @@ class ble_mitm(module.WirelessModule):
 
 
 		if utils.booleanArg(self.args["SLAVE_SPOOFING"]) and address != self.a2mEmitter.getAddress():
-			self.a2mEmitter.setAddress(address)
+			self.a2mEmitter.setAddress(address, random=addrType)
 		self.a2mEmitter.setScanningParameters(data=dataResponse)
-		self.a2mEmitter.setAdvertisingParameters(data=data, intervalMin=intervalMin, intervalMax=intervalMax, daType = addrType)
+		self.a2mEmitter.setAdvertisingParameters(data=data, intervalMin=intervalMin, intervalMax=intervalMax, daType=addrType, oaType=addrType)
 
 
 	# Connection related methods


### PR DESCRIPTION
Hey,
I think on this point was a little mistake.
On one hand pMin from the function declaration is unused and on the other hand is each searching interval from 0 to pMax.