### PR TITLE
Quick fix for L2CAP Command Identifier Header field. 

### DIFF
--- a/mirage/libs/ble.py
+++ b/mirage/libs/ble.py
@@ -623,7 +623,7 @@ class BLEEmitter(wireless.Emitter):
 						isinstance(packet,BLEConnectionParameterUpdateRequest) or
 					     	isinstance(packet,BLEConnectionParameterUpdateResponse)
 					   ):
-							packet.packet /= L2CAP_Hdr()/L2CAP_CmdHdr()
+							packet.packet /= L2CAP_Hdr()/L2CAP_CmdHdr(id=packet.l2capCmdId)
 					elif (
 						isinstance(packet,BLESecurityRequest) or
 						isinstance(packet,BLEPairingRequest) or
@@ -1024,6 +1024,7 @@ class BLEReceiver(wireless.Receiver):
 
 				elif L2CAP_Connection_Parameter_Update_Request in packet:
 					return BLEConnectionParameterUpdateRequest(
+						l2capCmdId = packet.id,
 						connectionHandle = packet.handle,
 						maxInterval=packet.max_interval,
 						minInterval=packet.min_interval,
@@ -1032,6 +1033,7 @@ class BLEReceiver(wireless.Receiver):
 						)
 				elif L2CAP_Connection_Parameter_Update_Response in packet:
 					return BLEConnectionParameterUpdateResponse(
+						l2capCmdId = packet.id,
 						connectionHandle = packet.handle,
 						moveResult=packet.move_result
 						) 
@@ -1046,6 +1048,7 @@ class BLEReceiver(wireless.Receiver):
 					return BLEConnectionCancel()
 				elif L2CAP_Connection_Parameter_Update_Request in packet:
 					return BLEConnectionParameterUpdateRequest(
+											l2capCmdId = packet.id,
 											connectionHandle = packet.handle,
 											maxInterval = packet.max_interval,
 											minInterval = packet.min_interval,
@@ -1054,6 +1057,7 @@ class BLEReceiver(wireless.Receiver):
 											)
 				elif L2CAP_Connection_Parameter_Update_Response in packet:
 					return BLEConnectionParameterUpdateResponse(
+											l2capCmdId = packet.id,
 											connectionHandle = packet.handle,
 											moveResult=packet.move_result)
 				elif HCI_Cmd_LE_Start_Encryption_Request in packet:

--- a/mirage/libs/ble_utils/packets.py
+++ b/mirage/libs/ble_utils/packets.py
@@ -1067,6 +1067,8 @@ class BLEConnectionParameterUpdateRequest(BLEPacket):
 	'''
 	Mirage Bluetooth Low Energy Packet - Connection Parameter Update Request
 
+	:param l2capCmdId
+	:type l2capCmdId: int
 	:param timeoutMult: timeout Multiplier
 	:type timeoutMult: int
 	:param slaveLatency: slave Latency
@@ -1083,8 +1085,9 @@ class BLEConnectionParameterUpdateRequest(BLEPacket):
 		>>> emitter.sendp(ble.BLEConnectionParameterUpdateRequest(timeoutMult=65535, minInterval=65535, maxInterval=65535, slaveLatency=0))
 
 	'''
-	def __init__(self,minInterval = 0, maxInterval = 0, slaveLatency = 0, timeoutMult = 0,connectionHandle = -1):
+	def __init__(self,l2capCmdId = 0, minInterval = 0, maxInterval = 0, slaveLatency = 0, timeoutMult = 0,connectionHandle = -1):
 		super().__init__()
+		self.l2capCmdId = l2capCmdId
 		self.timeoutMult = timeoutMult
 		self.slaveLatency = slaveLatency
 		self.minInterval = minInterval
@@ -1101,6 +1104,8 @@ class BLEConnectionParameterUpdateResponse(BLEPacket):
 	'''
 	Mirage Bluetooth Low Energy Packet - Connection Parameter Update Response
 
+	:param l2capCmdId
+	:type l2capCmdId: int
 	:param moveResult: move Result
 	:type moveResult: int
 	:param connectionHandle: connection handle associated to the connection
@@ -1111,8 +1116,9 @@ class BLEConnectionParameterUpdateResponse(BLEPacket):
 		>>> emitter.sendp(ble.BLEConnectionParameterUpdateResponse(moveResult=0))
 
 	'''
-	def __init__(self,moveResult = 0,connectionHandle = -1):
+	def __init__(self,l2capCmdId = 0, moveResult = 0,connectionHandle = -1):
 		super().__init__()
+		self.l2capCmdId = l2capCmdId
 		self.moveResult = moveResult
 		self.connectionHandle = connectionHandle
 		self.name = "BLE - Connection Parameter Update Response Packet"

--- a/mirage/modules/ble_master.py
+++ b/mirage/modules/ble_master.py
@@ -295,7 +295,7 @@ class ble_master(module.WirelessModule, interpreter.Interpreter):
 		io.info(" => Minimum interval: "+str(packet.minInterval))
 		io.info(" => Maximum interval: "+str(packet.maxInterval))
 		self.emitter.updateConnectionParameters(timeout=packet.timeoutMult,latency=packet.slaveLatency, minInterval=packet.minInterval,maxInterval=packet.maxInterval,minCe=0,maxCe=0)
-		self.emitter.sendp(ble.BLEConnectionParameterUpdateResponse(moveResult=0))
+		self.emitter.sendp(ble.BLEConnectionParameterUpdateResponse(l2capCmdId = packet.l2capCmdId,moveResult=0))
 
 	@module.scenarioSignal("onSlaveHandleValueNotification")
 	def onNotification(self,packet):

--- a/mirage/modules/ble_mitm.py
+++ b/mirage/modules/ble_mitm.py
@@ -602,11 +602,13 @@ class ble_mitm(module.WirelessModule):
 		io.info("Sending a response to slave ...")
 		self.a2sEmitter.updateConnectionParameters(timeout=packet.timeoutMult,latency=packet.slaveLatency, minInterval=packet.minInterval,maxInterval=packet.maxInterval,minCe=0,maxCe=0)
 		self.a2sEmitter.sendp(ble.BLEConnectionParameterUpdateResponse(
+						l2capCmdId = packet.l2capCmdId,
 						moveResult=0
 					))
 		if self.getStage() == BLEMitmStage.ACTIVE_MITM:
 			io.info("Redirecting to master ...")
-			self.a2mEmitter.sendp(ble.BLEConnectionParameterUpdateRequest(timeoutMult=packet.timeoutMult, slaveLatency=packet.slaveLatency, minInterval=packet.minInterval, maxInterval=packet.maxInterval))
+			self.a2mEmitter.sendp(ble.BLEConnectionParameterUpdateRequest(
+						l2capCmdId = packet.l2capCmdId,timeoutMult=packet.timeoutMult, slaveLatency=packet.slaveLatency, minInterval=packet.minInterval, maxInterval=packet.maxInterval))
 	
 			
 	@module.scenarioSignal("onMasterConnectionParameterUpdateResponse")


### PR DESCRIPTION
The Command Identifier in the L2CAP Response must match the Command Identifier from
the Request.